### PR TITLE
build node.js extensions with an 'init' symbol

### DIFF
--- a/Lib/javascript/v8/javascriptruntime.swg
+++ b/Lib/javascript/v8/javascriptruntime.swg
@@ -172,4 +172,8 @@ v8::Handle<v8::Object> SWIG_V8_NewPointerObj(void *ptr, swig_type_info *info, in
 #define SWIG_ConvertInstance(obj, pptr, type, flags)    SWIG_V8_ConvertInstancePtr(obj, pptr, type, flags)
 #define SWIG_NewInstanceObj(thisvalue, type, flags)     SWIG_V8_NewPointerObj(thisvalue, type, flags)
 
+#define SWIG_ConvertFunctionPtr(obj, pptr, type)        SWIG_V8_ConvertPtr(obj, pptr, type, 0)
+#define SWIG_NewFunctionPtrObj(ptr, type)               SWIG_V8_NewPointerObj(ptr, type, 0)
+
 %}
+

--- a/Lib/javascript/v8/node.i
+++ b/Lib/javascript/v8/node.i
@@ -1,4 +1,4 @@
-%insert("init") %{
+%insert("runtime") %{
 #ifndef BUILDING_NODE_EXTENSION
 #define BUILDING_NODE_EXTENSION
 #endif
@@ -9,6 +9,11 @@
 %define %node(moduleName)
 %insert("post-init") %{
 extern "C" {
+
+    void init(v8::Handle<v8::Object> target) {
+      moduleName ## _initialize(target);
+    }
+
     NODE_MODULE(moduleName, moduleName ## _initialize)
 }
 %}


### PR DESCRIPTION
Hi guys,

thanks to @oliver---- 's gist and his code, I got my header to SWIGify then compile, but only after adding the 'init' function which the node runtime looks for.

I also added two macros, which seem to make sense given equivalent macros for other languages - are they right?
