### PR TITLE
fixed deprecation warnings for v8-3.21

### DIFF
--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -141,8 +141,10 @@ void $jswrapper(v8::Isolate *isolate, v8::Persistent< v8::Object > * object, SWI
   object.Clear();
 #if (SWIG_V8_VERSION < 0x031900)
   object.Dispose();
-#else
+#elif (SWIG_V8_VERSION < 0x032100)
   object->Dispose(isolate);
+#else
+  object->Dispose();
 #endif
 }
 %}
@@ -171,8 +173,10 @@ void $jswrapper(v8::Isolate *isolate, v8::Persistent< v8::Object > * object, SWI
 
 #if (SWIG_V8_VERSION < 0x031900)
   object.Dispose();
-#else
+#elif (SWIG_V8_VERSION < 0x032100)
   object->Dispose(isolate);
+#else
+  object->Dispose();
 #endif
 }
 %}

--- a/Lib/javascript/v8/javascriptruntime.swg
+++ b/Lib/javascript/v8/javascriptruntime.swg
@@ -110,7 +110,7 @@ public:
   };
 
   ~SWIGV8_Proxy() {
-#if (SWIG_V8_VERSION < 0x031900)
+#if (SWIG_V8_VERSION < 0x031900 || SWIG_V8_VERSION >= 0x032100)
     handle.ClearWeak();
     handle.Dispose();
 #else
@@ -238,7 +238,13 @@ void SWIGV8_SetPrivateData(v8::Handle<v8::Object> obj, void* ptr, swig_type_info
   } else {
     cdata->handle.MakeWeak(v8::Isolate::GetCurrent(), cdata, SWIGV8_Proxy_DefaultDtor);
   }
-  cdata->handle.MarkIndependent(v8::Isolate::GetCurrent());
+
+#  if (SWIG_V8_VERSION < 0x032100)
+    cdata->handle.MarkIndependent(v8::Isolate::GetCurrent());
+#  else
+    cdata->handle.MarkIndependent();
+#  endif
+
 #endif
 }
 


### PR DESCRIPTION
They deprecated (Isolate *) variants for persistent handles introduced in .20 :+1: 
