### PR TITLE
fixed newer v8 compilation

### DIFF
--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -398,8 +398,8 @@ void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persistent< v8::Obj
 
   delete cdata;
 
-  object.Clear();
 #if (SWIG_V8_VERSION < 0x031900)
+  object.Clear();
   object.Dispose();
 #elif (SWIG_V8_VERSION < 0x032100)
   object->Dispose(isolate);

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -392,7 +392,7 @@ void _wrap_SwigV8PackedData_delete(v8::Persistent< v8::Value > object, void *par
 {
   SwigV8PackedData *cdata = static_cast<SwigV8PackedData *>(parameter);
 #else
-void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persistent< v8::Object > * object, SwigV8PackedData *proxy)
+void _wrap_SwigV8PackedData_delete(v8::Isolate *isolate, v8::Persistent< v8::Object > * object, SwigV8PackedData *cdata)
 {
 #endif
 


### PR DESCRIPTION
I noticed that PersistentHandle::Clear() in newer v8 code marked for removal and might not work as expected. 

template <class T>
void Persistent<T>::Dispose() {
  if (this->IsEmpty()) return; //**_Clear will trigger this**_
  V8::DisposeGlobal(reinterpret_castinternal::Object**(this->val_));
  ...
}
I put Clear into old branch of code, someone using old v8, please check that Dispose() with or without Clear() actually works as expected. 
