### PR TITLE
Fix function naming conflict with class overloads.

### DIFF
--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1207,18 +1207,22 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool /*is_member */ ) {
   // substract the extension "sym:overname",
   String *wrap_name = NewString(Getattr(n, "wrap:name"));
   String *overname = Getattr(n, "sym:overname");
+  Node *methodclass = Swig_methodclass(n);
+  String *class_name = Getattr(methodclass, "sym:name");
   int l1 = Len(wrap_name);
   int l2 = Len(overname);
   Delslice(wrap_name, l1 - l2, l1);
+  String *new_string = NewStringf("%s_%s", class_name, wrap_name);
+  String *final_wrap_name = Swig_name_wrapper(new_string);
 
-  Setattr(n, "wrap:name", wrap_name);
-  state.function(WRAPPER_NAME, wrap_name);
+  Setattr(n, "wrap:name", final_wrap_name);
+  state.function(WRAPPER_NAME, final_wrap_name);
 
   t_function.replace("$jslocals", wrapper->locals)
       .replace("$jscode", wrapper->code);
 
   // call this here, to replace all variables
-  t_function.replace("$jswrapper", wrap_name)
+  t_function.replace("$jswrapper", final_wrap_name)
       .replace("$jsname", state.function(NAME))
       .pretty_print(f_wrappers);
 


### PR DESCRIPTION
This fix takes into account the classname while generating overload
handlers.

Example:

If you have two classes:

  class A {
    public:
      void doSomething(int);
      void doSomething(double);
  };

  class B {
    public:
      void doSomething(int);
      void doSomething(double);
  };

Before this patch, the overload handlers for A::doSomething and
B::doSomething create conflicting names and function redefinition errors
are caused.

After the patch, the overload handlers are named classname_doSomething
and no longer conflict.

This is almost certainly not the best way to implement this, but it
solves a critical problem on large projects, and specifically can affect
operator overloads that are being wrapped.
